### PR TITLE
Replace H264 baseline with H264 constrained baseline

### DIFF
--- a/omx_utils/src/mfx_omx_dev_android.cpp
+++ b/omx_utils/src/mfx_omx_dev_android.cpp
@@ -320,13 +320,9 @@ VAProfile MfxOmxDevAndroid::ConvertProfileTypeMFX2VAAPI(OMX_U32 id, OMX_U32 type
 {
     VAProfile vaProfile;
 
-    if ((MFX_CODEC_AVC == id) && (MFX_PROFILE_AVC_CONSTRAINED_BASELINE == type))
+    if ((MFX_CODEC_AVC == id) && ((MFX_PROFILE_AVC_CONSTRAINED_BASELINE == type) || (MFX_PROFILE_AVC_BASELINE == type)))
     {
         vaProfile = VAProfileH264ConstrainedBaseline;     
-    }
-    else if ((MFX_CODEC_AVC == id) && (MFX_PROFILE_AVC_BASELINE == type))
-    {
-        vaProfile = VAProfileH264Baseline;
     }
     else if ((MFX_CODEC_AVC == id) && (MFX_PROFILE_AVC_MAIN == type))
     {


### PR DESCRIPTION
At vaGetConfigAttributes function, it should use H264
constrained baseline, because driver doesn't support
H264 baseline profile

Signed-off-by: Zhizhen Tang <zhizhen.tang@intel.com>